### PR TITLE
make 'show_grid' an option in plot_1

### DIFF
--- a/ecg_plot/ecg_plot.py
+++ b/ecg_plot/ecg_plot.py
@@ -7,22 +7,23 @@ import os
 from math import ceil 
 
 
-def _ax_plot(ax, x, y, secs=10, lwidth=0.5, amplitude_ecg = 1.8, time_ticks =0.2):
-    ax.set_xticks(np.arange(0,11,time_ticks))    
-    ax.set_yticks(np.arange(-ceil(amplitude_ecg),ceil(amplitude_ecg),1.0))
-
-    #ax.set_yticklabels([])
-    #ax.set_xticklabels([])
-
-    ax.minorticks_on()
+def _ax_plot(ax, x, y, secs=10, lwidth=0.5, amplitude_ecg = 1.8, time_ticks =0.2, show_grid=True):
     
-    ax.xaxis.set_minor_locator(AutoMinorLocator(5))
-
     ax.set_ylim(-amplitude_ecg, amplitude_ecg)
     ax.set_xlim(0, secs)
+    
+    if(show_grid):
+        ax.grid(which='major', linestyle='-', linewidth='0.5', color='red')
+        ax.grid(which='minor', linestyle='-', linewidth='0.5', color=(1, 0.7, 0.7))
 
-    ax.grid(which='major', linestyle='-', linewidth='0.5', color='red')
-    ax.grid(which='minor', linestyle='-', linewidth='0.5', color=(1, 0.7, 0.7))
+        ax.set_xticks(np.arange(0,11,time_ticks))    
+        ax.set_yticks(np.arange(-ceil(amplitude_ecg),ceil(amplitude_ecg),1.0))
+
+        ax.set_yticklabels([])
+        ax.set_xticklabels([])
+
+        ax.minorticks_on()
+        ax.xaxis.set_minor_locator(AutoMinorLocator(5))
 
     ax.plot(x,y, linewidth=lwidth)
 
@@ -195,7 +196,15 @@ def plot(
                     )
         
 
-def plot_1(ecg, sample_rate=500, title = 'ECG', fig_width = 15, fig_height = 2, line_w = 0.5, ecg_amp = 1.8, timetick = 0.2):
+def plot_1(ecg,
+           sample_rate=500,
+           title = 'ECG',
+           fig_width = 15,
+           fig_height = 2,
+           line_w = 0.5,
+           ecg_amp = 1.8,
+           timetick = 0.2,
+           show_grid=True):
     """Plot multi lead ECG chart.
     # Arguments
         ecg        : m x n ECG signal data, which m is number of leads and n is length of signal.
@@ -219,7 +228,7 @@ def plot_1(ecg, sample_rate=500, title = 'ECG', fig_width = 15, fig_height = 2, 
     ax = plt.subplot(1, 1, 1)
     #plt.rcParams['lines.linewidth'] = 5
     step = 1.0/sample_rate
-    _ax_plot(ax,np.arange(0,len(ecg)*step,step),ecg, seconds, line_w, ecg_amp,timetick)
+    _ax_plot(ax,np.arange(0,len(ecg)*step,step),ecg, seconds, line_w, ecg_amp,timetick, show_grid)
     
 DEFAULT_PATH = './'
 show_counter = 1
@@ -248,7 +257,11 @@ def save_as_png(file_name, path = DEFAULT_PATH, dpi = 100, layout='tight'):
         layout   : Set equal to "tight" to include ax labels on saved image
     """
     plt.ioff()
-    plt.savefig(path + file_name + '.png', dpi = dpi, bbox_inches=layout)
+    pad_inches = 0.1
+    if(layout != 'tight'):
+        plt.axis('off')
+        pad_inches = 0
+    plt.savefig(path + file_name + '.png', dpi = dpi, bbox_inches=layout, pad_inches=pad_inches)
     plt.close()
 
 def save_as_svg(file_name, path = DEFAULT_PATH):

--- a/ecg_plot/ecg_plot.py
+++ b/ecg_plot/ecg_plot.py
@@ -257,7 +257,7 @@ def save_as_png(file_name, path = DEFAULT_PATH, dpi = 100, layout='tight'):
         layout   : Set equal to "tight" to include ax labels on saved image
     """
     plt.ioff()
-    pad_inches = 0.1
+    pad_inches = 0.1  # it's the default
     if(layout != 'tight'):
         plt.axis('off')
         pad_inches = 0


### PR DESCRIPTION
## What?
I've added a "show_grid" parameter to the "plot_1" function.

## Why?
The "plot" function has it, so I expected "plot_1" to have it as well, but to my surprise, it didn't.

## How?
I needed to modify a little your "_ax_plot" function by also setting a "show_grid" parameter and moving the code that rendered the grid to inside an "if" that will only run if "show_grid" is True. I've made show_grid True by default so it would't break the other methods.

## Also
I've also explicitly disabled the axis in save_to_png when not passing layout='tight', because for some reason the axis were still being show in the png even if layout was None